### PR TITLE
fix: 适配新版洛谷 API ,优化了一些体验问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules/
 test.*
 1.html
 .vs/
+.claude/
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 4.13.0
+
+- Fix:
+  1. 适配洛谷 API 变更：题目标题从 `problem.title` 迁移至 `content.name`
+  2. 适配题单响应格式从 `DataResponse` 变为 `LentilleDataResponse`
+  3. 适配题单字段 `title` 重命名为 `name`，题目数组结构扁平化
+  4. 适配题单广场 `trainings.result` 支持 array/object 两种格式
+  5. 适配 `acceptedCounts` 重命名为 `acCounts`
+  6. 适配训练详情使用 `TrainingProblem` 的 `accepted`/`submitted` 字段
+  7. 解决最近浏览中题单图标偏移问题（`folder` → `folder-library`）
+- Add:
+  1. 刷新浏览记录命令（从 API 重新获取标题并去重）
+  2. 清空浏览记录命令（带确认对话框）
+
 ## 4.12.2
 
 - Add:
@@ -19,9 +33,9 @@
 - Add:
   1. 提交代码时若未聚焦任何编辑器则要求选择文件
   2. 重做比赛页面
-    1. 重做 UI
-    2. 自动刷新排行榜
-    3. 在任务栏显示比赛信息
+  3. 重做 UI
+  4. 自动刷新排行榜
+  5. 在任务栏显示比赛信息
 
 ## 4.11.12
 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ Follow [MIT](LICENSE) LICENSE.
 - [宝硕](https://baoshuo.ren)
 - 品小呈
 - MrPython
+- Enigma_Soul

--- a/package-lock.json
+++ b/package-lock.json
@@ -437,7 +437,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
       "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.1.0"
       },
@@ -1455,7 +1454,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
       "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.3.1",
         "@typescript-eslint/types": "7.3.1",
@@ -2177,7 +2175,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2243,7 +2240,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2669,7 +2665,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -3304,7 +3299,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
       "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -4286,7 +4280,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8405,7 +8398,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -8945,7 +8937,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9125,7 +9116,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10919,7 +10909,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
       "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11148,7 +11137,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -11644,7 +11632,6 @@
       "version": "5.94.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -11757,7 +11744,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "vscode-luogu",
   "description": "Solve Luogu Problems in VSCode",
   "icon": "resources/img/luogu-normal.png",
-  "version": "4.12.2",
+  "version": "4.13.0",
   "license": "MIT",
   "publisher": "yltx",
   "engines": {
@@ -167,6 +167,16 @@
       {
         "command": "luogu.jumpToCph",
         "title": "在 CPH 中打开当前题目"
+      },
+      {
+        "command": "luogu.history.refresh",
+        "title": "刷新浏览记录",
+        "category": "Luogu"
+      },
+      {
+        "command": "luogu.history.clear",
+        "title": "清空浏览记录",
+        "category": "Luogu"
       }
     ],
     "keybindings": [
@@ -527,8 +537,7 @@
           ],
           "default": "ProblemID",
           "description": "传送至 CPH 时，CPH 创建文件时的文件名形式。"
-        }
-        ,
+        },
         "luogu.cphPort": {
           "type": "integer",
           "default": 27121,

--- a/src/commands/traindetails/index.ts
+++ b/src/commands/traindetails/index.ts
@@ -24,7 +24,7 @@ export default new SuperCommand({
       // console.log(data)
       const panel = vscode.window.createWebviewPanel(
         '题单详情',
-        `${data['training']['title']}`,
+        `${data['training']['name'] ?? data['training']['title']}`,
         vscode.ViewColumn.Two,
         {
           enableScripts: true,

--- a/src/commands/traininglist/index.ts
+++ b/src/commands/traininglist/index.ts
@@ -27,7 +27,7 @@ export default new SuperCommand({
         const data = await searchTrainingdetail(message.data);
         const panel2 = vscode.window.createWebviewPanel(
           '题单详情',
-          `${data['training']['title']}`,
+          `${data['training']['name'] ?? data['training']['title']}`,
           vscode.ViewColumn.Two,
           {
             enableScripts: true,
@@ -210,8 +210,11 @@ const generategeneralHTML = async (webview: vscode.Webview) => {
 
 const generateOfficialListHTML = async (keyword: string, page: number) => {
   const data = await searchTraininglist('official', keyword, page);
-  const list = data['trainings']['result'];
-  const accepted = data['acceptedCounts'];
+  const trainings = data['trainings'];
+  const list = trainings?.['result'];
+  if (!list) return '<p>加载失败</p>';
+  const items: any[] = Array.isArray(list) ? list : Object.values(list);
+  const accepted = data['acCounts'] ?? data['acceptedCounts'];
   console.log(data);
   console.log(accepted);
   let html = '';
@@ -223,35 +226,32 @@ const generateOfficialListHTML = async (keyword: string, page: number) => {
   html += '          <th nowrap>题目数</th>\n';
   html += '          <th nowrap>收藏数</th>\n';
   html += '        </tr>\n';
-  for (let i = 1; i <= list['length']; i++) {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i] as any;
     html += '        <tr>\n';
-    html += `          <td align="left" nowrap>${list[i - 1]['id']}</td>\n`;
+    html += `          <td align="left" nowrap>${item['id']}</td>\n`;
     html += `          <td align="left" nowrap><a href="${
-      list[i - 1]['title']
-    }" class="detail_btn" id="${list[i - 1]['id']}">${
-      list[i - 1]['title']
+      item['name'] ?? item['title']
+    }" class="detail_btn" id="${item['id']}">${
+      item['name'] ?? item['title']
     }</a></td>\n`;
     html += `          <td align="left" nowrap>\n
-            <progress value="${accepted[list[i - 1]['id']]}" max="${
-              list[i - 1]['problemCount']
+            <progress value="${accepted[item['id']]}" max="${
+              item['problemCount']
             }" style="height: 30px;width: 100px;" title="${
-              accepted[list[i - 1]['id']]
-            }/${list[i - 1]['problemCount']}"></progress>
+              accepted[item['id']]
+            }/${item['problemCount']}"></progress>
                      </td>\n`;
     // html+=`          <td width="15px" align="left"></td>`
-    html += `          <td align="center" nowrap>${
-      list[i - 1]['problemCount']
-    }</td>\n`;
-    html += `          <td align="center" nowrap>${
-      list[i - 1]['markCount']
-    }</td>\n`;
+    html += `          <td align="center" nowrap>${item['problemCount']}</td>\n`;
+    html += `          <td align="center" nowrap>${item['markCount']}</td>\n`;
     html += '        <tr>\n';
   }
   html += '      </table>\n';
   html += `      <script>
       function turnOfficial(towards) {
         pageOfficial+=towards;
-        const count=${data['trainings']['count']};
+        const count=${trainings?.['count'] ?? items.length};
         console.log("official count:",count);
         if(pageOfficial<1){
           swal("好像哪里有点问题", "已经是第一页了", "error");
@@ -266,7 +266,7 @@ const generateOfficialListHTML = async (keyword: string, page: number) => {
       }
       function gotokthofficial() {
         const id=parseInt(document.getElementById('KTHOFFICIAL').value);
-        if(id<1||id>Math.ceil(${data['trainings']['count']}/50.0)){
+        if(id<1||id>Math.ceil(${trainings?.['count'] ?? items.length}/50.0)){
           swal("好像哪里有点问题", "不合法的页数", "error");
           return;
         }
@@ -294,7 +294,10 @@ const generateOfficialListHTML = async (keyword: string, page: number) => {
 };
 const generateSelectedListHTML = async (keyword: string, page: number) => {
   const data = await searchTraininglist('select', keyword, page);
-  const list = data['trainings']['result'];
+  const trainings = data['trainings'];
+  const list = trainings?.['result'];
+  if (!list) return '<p>加载失败</p>';
+  const items: any[] = Array.isArray(list) ? list : Object.values(list);
   console.log(data);
   let html = '';
   html += '      <table border="0" width="100%">\n';
@@ -305,25 +308,22 @@ const generateSelectedListHTML = async (keyword: string, page: number) => {
   html += '          <th nowrap>收藏数</th>\n';
   html += '          <th nowrap>创建者</th>\n';
   html += '        </tr>\n';
-  for (let i = 1; i <= list['length']; i++) {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i] as any;
     html += '        <tr>\n';
-    html += `          <td align="left" nowrap>${list[i - 1]['id']}</td>\n`;
+    html += `          <td align="left" nowrap>${item['id']}</td>\n`;
     html += `          <td align="left" nowrap><a href="${
-      list[i - 1]['title']
-    }" class="detail_btn" id="${list[i - 1]['id']}">${
-      list[i - 1]['title']
+      item['name'] ?? item['title']
+    }" class="detail_btn" id="${item['id']}">${
+      item['name'] ?? item['title']
     }</a></td>\n`;
-    html += `          <td align="left" nowrap>${
-      list[i - 1]['problemCount']
-    }</td>\n`;
+    html += `          <td align="left" nowrap>${item['problemCount']}</td>\n`;
     // html+=`          <td width="15px" align="left"></td>`
-    html += `          <td align="center" nowrap>${
-      list[i - 1]['markCount']
-    }</td>\n`;
+    html += `          <td align="center" nowrap>${item['markCount']}</td>\n`;
     html += `          <td align="center" style="font-weight: bold; color: ${getUsernameColor(
-      list[i - 1]['provider']['color']
-    )};" nowrap>${list[i - 1]['provider']['name']}${getUserSvg(
-      list[i - 1]['provider']['ccfLevel']
+      item['provider']['color']
+    )};" nowrap>${item['provider']['name']}${getUserSvg(
+      item['provider']['ccfLevel']
     )}</td>\n`;
     html += '        <tr>\n';
   }
@@ -331,7 +331,7 @@ const generateSelectedListHTML = async (keyword: string, page: number) => {
   html += `      <script>
       function turnSelected(towards) {
         page+=towards;
-        const count=${data['trainings']['count']};
+        const count=${trainings?.['count'] ?? items.length};
         console.log("selected count:",count);
         if(page<1){
           swal("好像哪里有点问题", "已经是第一页了", "error");
@@ -346,7 +346,7 @@ const generateSelectedListHTML = async (keyword: string, page: number) => {
       }
       function gotokthselected() {
         const id=parseInt(document.getElementById('KTHSELECTED').value);
-        if(id<1||id>Math.ceil(${data['trainings']['count']}/50.0)){
+        if(id<1||id>Math.ceil(${trainings?.['count'] ?? items.length}/50.0)){
           swal("好像哪里有点问题", "不合法的页数", "error");
           return;
         }

--- a/src/features/history/index.ts
+++ b/src/features/history/index.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import historyTreeviewProvider from './treeviewProvider';
 import { getStorage, setStorage } from '@/utils/storage';
+import {
+  getProblemData,
+  searchContest,
+  searchTrainingdetail
+} from '@/utils/api';
 
 const globalStateKey = 'luogu.history';
 export default function registerHistory(context: vscode.ExtensionContext) {
@@ -13,4 +18,49 @@ export default function registerHistory(context: vscode.ExtensionContext) {
   globalThis.luogu.historyTreeviewProvider = view;
   vscode.window.registerTreeDataProvider('luogu.history', view);
   context.subscriptions.push(view);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('luogu.history.refresh', async () => {
+      const items = await getStorage(context, 'history');
+      const seen = new Map<string, (typeof items)[number]>();
+      for (const item of items) {
+        let key: string;
+        if (item.type === 'problem')
+          key = `pid:${item.pid}${item.contest ? `:contest:${item.contest.contestId}` : ''}`;
+        else if (item.type === 'contest') key = `contest:${item.contestId}`;
+        else key = `training:${item.trainingId}`;
+        seen.set(key, item);
+      }
+      const refreshed = [...seen.values()];
+      for (const item of refreshed) {
+        try {
+          if (item.type === 'problem') {
+            const data = await getProblemData(
+              item.pid,
+              item.contest?.contestId
+            );
+            item.title = data.problem.title ?? data.problem.content.name;
+          } else if (item.type === 'contest') {
+            const data = await searchContest(item.contestId);
+            item.title = data.contest.name;
+          } else if (item.type === 'training') {
+            const data = await searchTrainingdetail(item.trainingId);
+            item.title = (data.training as any).name ?? data.training.title;
+          }
+        } catch {}
+      }
+      setStorage(context, 'history', refreshed);
+      view.refresh();
+    }),
+    vscode.commands.registerCommand('luogu.history.clear', async () => {
+      const result = await vscode.window.showWarningMessage(
+        '确定要清空所有浏览记录吗？',
+        { modal: true },
+        '确定'
+      );
+      if (result === '确定') {
+        view.clear();
+      }
+    })
+  );
 }

--- a/src/features/history/treeviewProvider.ts
+++ b/src/features/history/treeviewProvider.ts
@@ -75,7 +75,7 @@ export default class historyTreeviewProvider
           title: '打开题单',
           arguments: [element.trainingId]
         },
-        iconPath: new vscode.ThemeIcon('folder'),
+        iconPath: new vscode.ThemeIcon('folder-library'),
         tooltip: new vscode.MarkdownString(
           `[${element.trainingId}](https://www.luogu.com.cn/training/${element.trainingId}) ${element.title}  \n` +
             `创建者：[${element.owner.name}](https://www.luogu.com.cn${'uid' in element.owner ? `/user/${element.owner.uid}` : `/team/${element.owner.teamId}`})  \n` +
@@ -95,6 +95,10 @@ export default class historyTreeviewProvider
   }
   dispose() {
     this._onDidChangeTreeData.dispose();
+  }
+  clear() {
+    this.setStorage([]);
+    this.refresh();
   }
   async addItem(item: HistoryItem) {
     const dat = (await this.getStorage()).filter(

--- a/src/features/viewProblem/cph.ts
+++ b/src/features/viewProblem/cph.ts
@@ -72,7 +72,7 @@ export async function sendCphMessage(data: ProblemData) {
           ? ' - ' + data.problem.pid
           : '') +
         (config === 'ProblemName' || config === 'ProblemIDwithProblemName'
-          ? ' - ' + data.problem.title
+          ? ' - ' + (data.problem.title ?? data.problem.content.name)
           : ''),
       url:
         'https://www.luogu.com.cn/problem/' +

--- a/src/features/viewProblem/index.ts
+++ b/src/features/viewProblem/index.ts
@@ -37,7 +37,8 @@ export default function registerViewProblem(context: vscode.ExtensionContext) {
                     title: problemData.contest.name
                   }
                 : undefined,
-              title: problemData.problem.title
+              title:
+                problemData.problem.title ?? problemData.problem.content.name
             });
             showProblemWebview(problemData);
             return true;

--- a/src/features/viewProblem/webview.ts
+++ b/src/features/viewProblem/webview.ts
@@ -8,7 +8,7 @@ import jumpToCphEventEmitter from './jumpToCphEventEmitter';
 export default function showProblemWebview(data: ProblemData) {
   const panel = vscode.window.createWebviewPanel(
     'luogu.problemPanel',
-    `${data.problem.pid} ${data.problem.title}`,
+    `${data.problem.pid} ${data.problem.title ?? data.problem.content.name}`,
     vscode.ViewColumn.Two,
     {
       enableScripts: true,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -16,7 +16,6 @@ import {
   LoginRequest,
   LoginResponse,
   ProblemData,
-  ProblemSetData,
   RecordBase,
   RecordData,
   SolutionsData,
@@ -287,7 +286,10 @@ export const searchTraininglist = async (
 ) =>
   axios
     .get(API.SEARCHTRAINLIST(type, keyword, page))
-    .then(res => res?.data?.currentData)
+    .then(res => {
+      const d = res.data;
+      return d.currentData ?? d.data;
+    })
     .then(async res => {
       // console.log(res)
       if ((res || null) === null) {
@@ -307,8 +309,11 @@ export const searchTraininglist = async (
 
 export const searchTrainingdetail = async (id: number) =>
   axios
-    .get<DataResponse<ProblemSetData>>(API.TRAINLISTDETAIL(id))
-    .then(res => res.data.currentData)
+    .get(API.TRAINLISTDETAIL(id))
+    .then(res => {
+      const d = res.data;
+      return d.currentData ?? d.data;
+    })
     .then(async res => {
       // console.log(res)
       if ((res || null) === null) {

--- a/src/utils/showTrainDetails.ts
+++ b/src/utils/showTrainDetails.ts
@@ -68,7 +68,7 @@ export class TrainDetals {
   } | null;
 
   public constructor(fields: ProblemSetDetails) {
-    this.title = fields.title;
+    this.title = (fields as any).name ?? fields.title;
     this.problemCount = fields.problemCount;
     this.problemlist = fields.problems;
     this.description = fields.description;
@@ -89,26 +89,21 @@ export class TrainDetals {
       problemlist += '  </tr>\n';
     }
     this.problemlist.forEach(index => {
+      const p = (index as any)['problem'] ?? index;
+      const score = p['accepted'] ? 1 : p['submitted'] ? 0 : -1;
       problemlist += `  <tr>
-    <td nowrap>${index['problem']['pid']}</td>
-    <td style="text-align: center;" nowrap>${getUserScoreStatus(
-      this.userScore
-        ? this.userScore['status'][index['problem']['pid']]
-          ? this.userScore['score'][index['problem']['pid']]
-          : -1
-        : -1,
-      index['problem']['fullScore']
-    )}</td>
+    <td nowrap>${p['pid']}</td>
+    <td style="text-align: center;" nowrap>${getUserScoreStatus(score, 1)}</td>
     <td align="left" nowrap><a href="${
-      index['problem']['pid']
-    }" class="pid" id="${index['problem']['pid']}">${md.render(
-      index['problem']['title']
+      p['pid']
+    }" class="pid" id="${p['pid']}">${md.render(
+      p['name'] ?? p['title'] ?? ''
     )}</a></td>
-    <td align="left" nowrap>${getTagsStatus(index['problem']['tags'])}</td>
-    <td nowrap>${getDifficultyStatus(index['problem']['difficulty']!)}</td>
+    <td align="left" nowrap>${getTagsStatus(p['tags'])}</td>
+    <td nowrap>${getDifficultyStatus(p['difficulty']!)}</td>
     <td nowrap>
-      <progress value="${index['problem']['totalAccepted']}" max="${
-        index['problem']['totalSubmit']
+      <progress value="${p['totalAccepted']}" max="${
+        p['totalSubmit']
       }" style="height: 30px;width: 100px;"></progress>
     </td>
 </tr>`;
@@ -131,7 +126,7 @@ export const showTrainDetails = async (webview: vscode.Webview, id: number) => {
   const train = await searchTrainingdetail(id).then(res => {
     globalThis.luogu.historyTreeviewProvider.addItem({
       type: 'training',
-      title: res.training.title,
+      title: (res.training as any).name ?? res.training.title,
       trainingId: res.training.id,
       trainingType: res.training.type,
       owner:

--- a/webview/views/viewProblem/app.tsx
+++ b/webview/views/viewProblem/app.tsx
@@ -60,7 +60,7 @@ export default function Problem({ children: data }: { children: ProblemData }) {
             >
               {data.problem.pid}
             </a>{' '}
-            {data.problem.title}
+            {data.problem.title ?? data.problem.content.name}
           </h1>
           <div>
             {languagesList.length > 1 && (


### PR DESCRIPTION
总结
- 适配洛谷新前端 API 变更，修复题目标题 undefined、题单广场/详情无法加载等问题
- 添加刷新/清空浏览记录功能

修复
- 题目标题从 problem.title 迁移至 content.name，兼容两种格式
- 题单响应格式从 DataResponse 变为 LentilleDataResponse，使用 currentData ?? data 兼容
- 题单字段 title 重命名为 name，题目数组结构扁平化
- 题单广场 trainings.result 支持 array/object 两种返回格式
- acceptedCounts 重命名为 acCounts
- 训练详情使用 TrainingProblem 的 accepted/submitted 布尔值替代旧的 per-PID score
- 最近浏览中题单图标偏移（folder → folder-library）

新增
- Luogu: 刷新浏览记录 命令（从 API 重新获取标题并去重）
- Luogu: 清空浏览记录 命令（带确认对话框）