### PR TITLE
fix(article): 更新专栏 API 端点、适配子模块类型并移除 promotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,10 +129,6 @@
         "title": "删除文章"
       },
       {
-        "command": "luogu.myarticle.setPromoteStatus",
-        "title": "申请/撤回全站推荐"
-      },
-      {
         "command": "luogu.myarticle.setSolutionFor",
         "title": "修改关联的题目"
       },
@@ -292,11 +288,6 @@
           "group": "navigation@7"
         },
         {
-          "command": "luogu.myarticle.setPromoteStatus",
-          "when": "view == luogu.myarticle && viewItem =~ /^luogu.article.articleitem/",
-          "group": "navigation@6"
-        },
-        {
           "command": "luogu.myarticle.setSolutionFor",
           "when": "view == luogu.myarticle && viewItem =~ /^luogu.article.articleitem.solution/",
           "group": "navigation@5"
@@ -345,10 +336,6 @@
         },
         {
           "command": "luogu.myarticle.delete",
-          "when": "false"
-        },
-        {
-          "command": "luogu.myarticle.setPromoteStatus",
           "when": "false"
         },
         {

--- a/src/features/contest/index.ts
+++ b/src/features/contest/index.ts
@@ -27,8 +27,8 @@ export default function registerContest(context: vscode.ExtensionContext) {
               title: contestData.contest.name,
               startTime: contestData.contest.startTime,
               endTime: contestData.contest.endTime,
-              ruleType: contestData.contest.ruleType,
-              visibilityType: contestData.contest.visibilityType,
+              ruleType: contestData.contest.method,
+              visibilityType: contestData.contest.visibility,
               owner:
                 'uid' in contestData.contest.host
                   ? {
@@ -39,7 +39,7 @@ export default function registerContest(context: vscode.ExtensionContext) {
                       teamId: contestData.contest.host.id,
                       name: contestData.contest.host.name
                     },
-              rated: contestData.contest.rated
+              rated: !!contestData.contest.rated
             });
             showContestWebview(contestData);
             return true;

--- a/src/features/contest/webview.ts
+++ b/src/features/contest/webview.ts
@@ -58,7 +58,7 @@ export default function showContestWebview(data: ContestData) {
     },
     ContestJoin: async () => {
       const body: { code?: string; unrated?: boolean } = {};
-      if (ContestVisibilityTypes[data.contest.visibilityType].invitation) {
+      if (ContestVisibilityTypes[data.contest.visibility].invitation) {
         const code = await vscode.window.showInputBox({
           prompt: '请输入比赛邀请码',
           placeHolder: '邀请码'

--- a/src/features/myArticle/fsProvider.ts
+++ b/src/features/myArticle/fsProvider.ts
@@ -44,7 +44,7 @@ export default class myArticleFsProvider
       const res = (await getArticle(uri.query)).data.article;
       return {
         type: vscode.FileType.File,
-        size: res.content.length,
+        size: (res.content ?? '').length,
         ctime: res.time,
         mtime: 0
       };
@@ -105,7 +105,7 @@ export default class myArticleFsProvider
         category: res.category,
         status: res.status,
         content: new TextDecoder().decode(content),
-        top: res.top
+        top: res.top ?? 0
       });
       this._onDidChangeFile.fire([
         { type: vscode.FileChangeType.Changed, uri }

--- a/src/features/myArticle/index.ts
+++ b/src/features/myArticle/index.ts
@@ -3,12 +3,7 @@ import MyArticleTreeviewProvider from './treeviewProvider';
 import myArticleFsProvider from './fsProvider';
 import { Article } from 'luogu-api';
 import { ArticleCategory } from '@/utils/shared';
-import {
-  editArticle,
-  getArticle,
-  requestPromotion,
-  withdrawPromotion
-} from '@/utils/api';
+import { editArticle, getArticle } from '@/utils/api';
 import { isAxiosError } from 'axios';
 import { processAxiosError } from '@/utils/workspaceUtils';
 
@@ -68,8 +63,8 @@ export default function registerMyArticle(context: vscode.ExtensionContext) {
           solutionFor: solutionFor,
           category: x,
           status: res.status,
-          content: res.content,
-          top: res.top
+          content: res.content ?? '',
+          top: res.top ?? 0
         }).catch(e => {
           if (isAxiosError(e) && e.response)
             vscode.window.showErrorMessage(e.response.data.errorMessage);
@@ -93,8 +88,8 @@ export default function registerMyArticle(context: vscode.ExtensionContext) {
           solutionFor: res.solutionFor?.pid ?? null,
           category: res.category,
           status: choice === '显示' ? 2 : 1,
-          content: res.content,
-          top: res.top
+          content: res.content ?? '',
+          top: res.top ?? 0
         }).catch(e => {
           if (isAxiosError(e) && e.response)
             vscode.window.showErrorMessage(e.response.data.errorMessage);
@@ -114,18 +109,9 @@ export default function registerMyArticle(context: vscode.ExtensionContext) {
           solutionFor: res.solutionFor?.pid ?? null,
           category: res.category,
           status: res.status,
-          content: res.content,
-          top: res.top
+          content: res.content ?? '',
+          top: res.top ?? 0
         }).catch(processAxiosError('重命名文章'));
-        view.refresh();
-      }
-    ),
-    vscode.commands.registerCommand(
-      'luogu.myarticle.setPromoteStatus',
-      async (item: Article) => {
-        await (item.promoteStatus === 0 ? requestPromotion : withdrawPromotion)(
-          item.lid
-        ).catch(processAxiosError('申请/撤销推荐'));
         view.refresh();
       }
     ),
@@ -194,8 +180,8 @@ export default function registerMyArticle(context: vscode.ExtensionContext) {
           solutionFor: problem || null,
           category: res.category,
           status: res.status,
-          content: res.content,
-          top: res.top
+          content: res.content ?? '',
+          top: res.top ?? 0
         }).catch(processAxiosError('设置关联题目'));
         view.refresh();
       }
@@ -208,7 +194,7 @@ export default function registerMyArticle(context: vscode.ExtensionContext) {
           title: '置顶量',
           ignoreFocusOut: true,
           placeHolder: '0 到 255 之间的整数。越高的值越靠前。',
-          value: res.top.toString(),
+          value: (res.top ?? 0).toString(),
           validateInput: value => {
             if (!/^\d+$/.test(value)) return '请输入 0 到 255 之间的整数';
             const num = parseInt(value);
@@ -222,7 +208,7 @@ export default function registerMyArticle(context: vscode.ExtensionContext) {
           solutionFor: res.solutionFor?.pid ?? null,
           category: res.category,
           status: res.status,
-          content: res.content,
+          content: res.content ?? '',
           top: parseInt(top)
         }).catch(processAxiosError('设置置顶量'));
         view.refresh();

--- a/src/model/article.ts
+++ b/src/model/article.ts
@@ -9,7 +9,7 @@ export default class ArticleData {
   constructor(article: import('luogu-api').ArticleDetails) {
     this.lid = article.lid;
     this.author = new UserInfoWithIcon(article.author);
-    this.content = article.content;
+    this.content = article.content ?? '';
     this.createTime = article.time * 1000;
     this.vote = { upvotes: article.upvote, voted: article.voted as -1 | 0 | 1 };
   }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -71,14 +71,11 @@ export namespace API {
     )}&_contentOnly=1`;
   export const SOLUTION_REFERER = (pid: string) => `/problem/solution/${pid}`;
   export const MYARTICLE = `/article/mine?_contentOnly`,
-    DELETE_ARTICLE = (lid: string) => `${apiURL}/article/delete/${lid}`,
-    EDIT_ARTICLE = (lid: string) => `${apiURL}/article/edit/${lid}`,
+    DELETE_ARTICLE = (lid: string) => `/article/${lid}/delete`,
+    EDIT_ARTICLE = (lid: string) => `/article/${lid}/editSubmit`,
     GET_ARTICLE = (lid: string) => `/article/${lid}?_contentOnly`,
-    REQUEST_PROMOTION = (lid: string) => `/api/article/requestPromotion/${lid}`,
-    WITHDRAW_PROMOTION = (lid: string) =>
-      `/api/article/withdrawPromotion/${lid}`,
-    CREATE_ARTICLE = '/api/article/new';
-  export const VOTE_ARTICLE = (lid: string) => `/api/article/vote/${lid}`;
+    CREATE_ARTICLE = '/article/_newSubmit';
+  export const VOTE_ARTICLE = (lid: string) => `/article/${lid}/vote`;
   export const CSRF_TOKEN = `/ranking`;
   export const CLIENT_ID = `/auth/login`;
 }
@@ -675,7 +672,7 @@ export const listMyArticles = async (params: {
       ).flat()
     ]),
   deleteArticle = async (lid: string) =>
-    axios.post<{ lid: string }>(API.DELETE_ARTICLE(lid)).then(x => x.data),
+    axios.post<{ lid: string }>(API.DELETE_ARTICLE(lid), {}).then(x => x.data),
   editArticle = async (lid: string, data: EditArticleRequest) =>
     axios
       .post<{ article: ArticleDetails }>(API.EDIT_ARTICLE(lid), data)
@@ -684,10 +681,6 @@ export const listMyArticles = async (params: {
     axios
       .get<LentilleDataResponse<ArticleData>>(API.GET_ARTICLE(lid))
       .then(x => x.data),
-  requestPromotion = async (lid: string) =>
-    axios.post<void>(API.REQUEST_PROMOTION(lid)).then(x => x.data),
-  withdrawPromotion = async (lid: string) =>
-    axios.post<void>(API.WITHDRAW_PROMOTION(lid)).then(x => x.data),
   createArticle = async (data: EditArticleRequest) =>
     axios
       .post<{ article: ArticleDetails }>(API.CREATE_ARTICLE, data)

--- a/src/utils/showTrainDetails.ts
+++ b/src/utils/showTrainDetails.ts
@@ -64,7 +64,7 @@ export class TrainDetals {
   } | null;
 
   public constructor(fields: ProblemSetDetails) {
-    this.title = (fields as any).name ?? fields.title;
+    this.title = fields.name;
     this.problemCount = fields.problemCount;
     this.problemlist = fields.problems;
     this.description = fields.description;

--- a/webview/views/contest/app.tsx
+++ b/webview/views/contest/app.tsx
@@ -75,8 +75,8 @@ export default function App({
             <a href={`https://www.luogu.com.cn/contest/${data.contest.id}`}>
               {data.contest.id}
             </a>{' '}
-            <Tag>{ContestRuleTypes[data.contest.ruleType]}</Tag>
-            <Tag>{ContestVisibilityTypes[data.contest.visibilityType]}</Tag>
+            <Tag>{ContestRuleTypes[data.contest.method]}</Tag>
+            <Tag>{ContestVisibilityTypes[data.contest.visibility]}</Tag>
             {data.contest.rated && <Tag color={ColorPalette['cyan-3']}>咕</Tag>}
             {data.contest.eloThreshold !== null &&
               data.contest.eloThreshold >= 0 && (
@@ -187,7 +187,7 @@ export default function App({
                     </a>
                   </div>
                   <div className="cp-col cp-col-submitted">
-                    {p.submitted && (
+                    {p.problem.submitted && (
                       <FontAwesomeIcon
                         icon={faCheck}
                         className="submitted-icon"

--- a/webview/views/contest/ranklist.tsx
+++ b/webview/views/contest/ranklist.tsx
@@ -13,7 +13,9 @@ const { formatTime, formatDate } = await import('@/utils/stringUtils');
 import type {
   GetScoreboardResponse,
   Score,
-  LegacyProblemSummary
+  ProblemSummary,
+  ProblemStatus,
+  Maybe
 } from 'luogu-api';
 import './ranklist.css';
 import { ColoredScore } from './scoreUtils';
@@ -21,7 +23,10 @@ import { ColoredScore } from './scoreUtils';
 export default function Ranklist({
   problems
 }: {
-  problems: { score: number; problem: LegacyProblemSummary }[];
+  problems: {
+    score: number;
+    problem: ProblemSummary & Maybe<ProblemStatus> & { fullScore?: number };
+  }[];
 }) {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -92,7 +97,7 @@ export default function Ranklist({
   }, [autoRefresh, page]);
 
   const contestFullScore = problems.reduce(
-    (a, b) => a + Math.floor((b.score / 100) * b.problem.fullScore),
+    (a, b) => a + Math.floor((b.score / 100) * (b.problem.fullScore ?? 0)),
     0
   );
 
@@ -130,7 +135,7 @@ export default function Ranklist({
                     <UserName user={new UserInfo(s.user)} />
                   </div>
                   <div className="cr-col cr-col-score">
-                    <ColoredScore full={contestFullScore} score={s.score} />
+                    <ColoredScore full={contestFullScore} score={s.score ?? 0} />
                     <span>({formatTime(s.runningTime)})</span>
                   </div>
                   {problems.map(p => {
@@ -147,7 +152,7 @@ export default function Ranklist({
                           <>
                             <ColoredScore
                               full={Math.floor(
-                                (p.score / 100) * p.problem.fullScore
+                                (p.score / 100) * (p.problem.fullScore ?? 0)
                               )}
                               score={detail.score}
                             />


### PR DESCRIPTION
## 背景

整改自 #176（按维护者反馈拆分）。本 PR 仅含专栏 API 相关的功能修复与类型适配，剥离格式化与版本发布。

## 改动

- 文章端点（create/edit/delete/vote）迁移至当前洛谷 API
- **移除未实现的申请/撤回全站推荐功能**：删除 handler、API wrapper 及 `package.json` 的 command/menu/commandPalette 声明，保持贡献点与代码一致（替代 #176 中保留注释死代码的方案）
- 适配 `luogu-api-docs` 子模块类型变更：contest（`ruleType`→`method`、`visibilityType`→`visibility`、`rated` 布尔化）、Article（`content`/`top` 可选）、ProblemSet（`title`→`name`）、contestProblems 结构

## 说明

- promotion 相关代码与声明已彻底清除（grep 验证为空）
- 保留 `promoteStatus` 数据字段的业务守卫（setCategory/setShowMode/fsProvider/treeview）
- 格式化改动与版本发布已拆分到独立的 style PR

## Test plan

- [x] `npm run typecheck`（0 错误）
- [x] `npm run test`（52/52）
- [x] promotion 声明与代码一致（package.json 三处已删，JSON 合法）
