### PR TITLE
#131: 题解页面增加管理员提示标签

### DIFF
--- a/src/model/article.ts
+++ b/src/model/article.ts
@@ -4,12 +4,14 @@ export default class ArticleData {
   lid: string;
   author: UserInfoWithIcon;
   content: string;
+  adminNote: string | null;
   createTime: number;
   vote: { upvotes: number; voted: -1 | 0 | 1 };
   constructor(article: import('luogu-api').ArticleDetails) {
     this.lid = article.lid;
     this.author = new UserInfoWithIcon(article.author);
     this.content = article.content ?? '';
+    this.adminNote = article.adminNote;
     this.createTime = article.time * 1000;
     this.vote = { upvotes: article.upvote, voted: article.voted as -1 | 0 | 1 };
   }

--- a/webview/views/solution/app.css
+++ b/webview/views/solution/app.css
@@ -48,6 +48,35 @@ body {
   line-height: 1.7;
 }
 
+.solution-admin-note {
+  padding: 14px 18px;
+  margin-bottom: 20px;
+  background: var(
+    --vscode-inputValidation-errorBackground,
+    rgb(255 80 80 / 8%)
+  );
+  border-left: 6px solid
+    var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+}
+
+.solution-admin-note-title {
+  margin-bottom: 6px;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.solution-admin-note-content {
+  line-height: 1.6;
+}
+
+.solution-admin-note-content > article > :first-child {
+  margin-top: 0;
+}
+
+.solution-admin-note-content > article > :last-child {
+  margin-bottom: 0;
+}
+
 .solution-content article img {
   max-width: 100%;
   height: auto;

--- a/webview/views/solution/app.tsx
+++ b/webview/views/solution/app.tsx
@@ -67,6 +67,14 @@ function SolutionPage({
                 </a>
               </span>
             </header>
+            {article.adminNote && (
+              <aside className="solution-admin-note" role="note">
+                <div className="solution-admin-note-title">管理员提示：</div>
+                <div className="solution-admin-note-content">
+                  <Md>{article.adminNote}</Md>
+                </div>
+              </aside>
+            )}
             <div className="solution-content">
               <Md>{article.content}</Md>
             </div>


### PR DESCRIPTION
完成 #131 放了一年的 issue 不搞搞是不有点不地道了（）

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/f26e9fb2-c20e-40be-b91e-78abcec4e91b" />