### PR TITLE
feat: #206 & 洛谷 markdown 新特性支持

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^18.2.0",
         "rehype-highlight": "^7.0.0",
         "rehype-react": "^8.0.0",
+        "remark-directive": "3.0.1",
         "unist-util-visit": "^5.0.0",
         "ws": "8.21.1"
       },
@@ -7198,6 +7199,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -7611,6 +7633,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -9493,6 +9534,22 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-jsx-runtime": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -642,6 +642,7 @@
     "react-dom": "^18.2.0",
     "rehype-highlight": "^7.0.0",
     "rehype-react": "^8.0.0",
+    "remark-directive": "3.0.1",
     "unist-util-visit": "^5.0.0",
     "ws": "8.21.1"
   },

--- a/webview/markdownViewer/index.ts
+++ b/webview/markdownViewer/index.ts
@@ -7,8 +7,12 @@ const { visit, SKIP } = await import('unist-util-visit');
 const { faBilibili } = await import('@fortawesome/free-brands-svg-icons');
 const { icon } = await import('@fortawesome/fontawesome-svg-core');
 const { default: rehypeHighlight } = await import('rehype-highlight');
+const { default: remarkDirective } = await import('remark-directive');
+const { remarkLuoguMarkdownExtensions, rehypeLuoguMarkdownExtensions } =
+  await import('./luoguMarkdownExtensions');
 await import('../copyablePreElement');
 import './hljsTheme';
+import './luoguMarkdownExtensions.css';
 import 'katex/dist/katex.css';
 
 const bilibiliIconHastElement = hastUtilFromHtml(icon(faBilibili).html[0], {
@@ -24,8 +28,10 @@ const rehypeReactConfig: import('hast-util-to-jsx-runtime').Options = {
 };
 
 const processor = getLuoguProcessor({
+  remarkPlugins: [remarkDirective, remarkLuoguMarkdownExtensions],
   rehypePlugins: [
     rehypeHighlight,
+    rehypeLuoguMarkdownExtensions,
     // vscode 里没法放 bilibili 的 iframe，拿链接顶一下
     () => (tree: import('hast').Root) =>
       visit(tree, 'element', function (e) {

--- a/webview/markdownViewer/luoguMarkdownExtensions.css
+++ b/webview/markdownViewer/luoguMarkdownExtensions.css
@@ -8,10 +8,11 @@
 
 .luogu-epigraph {
   box-sizing: border-box;
-  width: min(100%, 25rem);
-  margin: 1em 0 1em auto;
+  width: 50%;
+  margin: 1em 0 1em 50%;
   padding: 0;
   border-left: 0;
+  background: transparent;
 }
 
 .luogu-epigraph > :not(footer) {

--- a/webview/markdownViewer/luoguMarkdownExtensions.css
+++ b/webview/markdownViewer/luoguMarkdownExtensions.css
@@ -19,7 +19,7 @@
   margin: 0;
 }
 
-.luogu-epigraph:has(> footer) > :nth-last-child(2) {
+.luogu-epigraph-with-footer > :nth-last-child(2) {
   padding-bottom: 0.15em;
   border-bottom: 1px solid var(--vscode-foreground);
 }
@@ -31,25 +31,53 @@
 
 .luogu-callout {
   --luogu-callout-color: var(--vscode-textLink-foreground);
+  --luogu-callout-background: var(
+    --vscode-inputValidation-infoBackground,
+    transparent
+  );
+  --luogu-callout-border: var(
+    --vscode-inputValidation-infoBorder,
+    var(--luogu-callout-color)
+  );
   margin: 1em 0;
   padding: 0.75em 1em;
-  border: 1px solid
-    color-mix(in srgb, var(--luogu-callout-color) 45%, transparent);
+  border: 1px solid var(--luogu-callout-border);
   border-left: 4px solid var(--luogu-callout-color);
   border-radius: 4px;
-  background: color-mix(in srgb, var(--luogu-callout-color) 8%, transparent);
+  background: var(--luogu-callout-background);
 }
 
 .luogu-callout-success {
   --luogu-callout-color: var(--vscode-testing-iconPassed, #2ea043);
+  --luogu-callout-background: var(
+    --vscode-editorWidget-background,
+    transparent
+  );
+  --luogu-callout-border: var(--luogu-callout-color);
 }
 
 .luogu-callout-warning {
   --luogu-callout-color: var(--vscode-editorWarning-foreground, #d29922);
+  --luogu-callout-background: var(
+    --vscode-inputValidation-warningBackground,
+    transparent
+  );
+  --luogu-callout-border: var(
+    --vscode-inputValidation-warningBorder,
+    var(--luogu-callout-color)
+  );
 }
 
 .luogu-callout-error {
   --luogu-callout-color: var(--vscode-editorError-foreground, #f85149);
+  --luogu-callout-background: var(
+    --vscode-inputValidation-errorBackground,
+    transparent
+  );
+  --luogu-callout-border: var(
+    --vscode-inputValidation-errorBorder,
+    var(--luogu-callout-color)
+  );
 }
 
 .luogu-callout > summary {
@@ -82,7 +110,7 @@ pre .luogu-code-line {
   padding: 0 0.75em;
 }
 
-pre code:has(> .luogu-code-line) {
+pre.luogu-code-enhanced code {
   display: block;
   margin: 0 -0.75em;
 }

--- a/webview/markdownViewer/luoguMarkdownExtensions.css
+++ b/webview/markdownViewer/luoguMarkdownExtensions.css
@@ -1,0 +1,101 @@
+.luogu-align-center {
+  text-align: center;
+}
+
+.luogu-align-right {
+  text-align: right;
+}
+
+.luogu-epigraph {
+  margin: 1em 0;
+  padding: 0.75em 1em;
+}
+
+.luogu-epigraph > footer {
+  margin-top: 0.5em;
+  text-align: right;
+}
+
+.luogu-callout {
+  --luogu-callout-color: var(--vscode-textLink-foreground);
+  margin: 1em 0;
+  padding: 0.75em 1em;
+  border: 1px solid
+    color-mix(in srgb, var(--luogu-callout-color) 45%, transparent);
+  border-left: 4px solid var(--luogu-callout-color);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--luogu-callout-color) 8%, transparent);
+}
+
+.luogu-callout-success {
+  --luogu-callout-color: var(--vscode-testing-iconPassed, #2ea043);
+}
+
+.luogu-callout-warning {
+  --luogu-callout-color: var(--vscode-editorWarning-foreground, #d29922);
+}
+
+.luogu-callout-error {
+  --luogu-callout-color: var(--vscode-editorError-foreground, #f85149);
+}
+
+.luogu-callout > summary {
+  color: var(--luogu-callout-color);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.luogu-callout[open] > summary {
+  margin-bottom: 0.5em;
+}
+
+.luogu-callout > :last-child {
+  margin-bottom: 0;
+}
+
+.luogu-cute-table-tuack th,
+.luogu-cute-table-tuack td {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.luogu-cute-table-tuack th {
+  background: var(--vscode-list-hoverBackground);
+}
+
+pre .luogu-code-line {
+  display: block;
+  min-height: 1em;
+  padding: 0 0.75em;
+}
+
+pre code:has(> .luogu-code-line) {
+  display: block;
+  margin: 0 -0.75em;
+}
+
+pre.luogu-code-line-numbers code {
+  counter-reset: luogu-code-line;
+}
+
+pre.luogu-code-line-numbers .luogu-code-line {
+  position: relative;
+  padding-left: 4.25em;
+}
+
+pre.luogu-code-line-numbers .luogu-code-line::before {
+  position: absolute;
+  left: 0;
+  width: 3.25em;
+  counter-increment: luogu-code-line;
+  content: counter(luogu-code-line);
+  color: var(--vscode-editorLineNumber-foreground);
+  text-align: right;
+  user-select: none;
+}
+
+pre .luogu-code-line-highlighted {
+  background: var(--vscode-editor-rangeHighlightBackground);
+  box-shadow: inset 3px 0
+    var(--vscode-editor-rangeHighlightBorder, var(--vscode-textLink-foreground));
+}

--- a/webview/markdownViewer/luoguMarkdownExtensions.css
+++ b/webview/markdownViewer/luoguMarkdownExtensions.css
@@ -7,12 +7,24 @@
 }
 
 .luogu-epigraph {
-  margin: 1em 0;
-  padding: 0.75em 1em;
+  box-sizing: border-box;
+  width: min(100%, 25rem);
+  margin: 1em 0 1em auto;
+  padding: 0;
+  border-left: 0;
+}
+
+.luogu-epigraph > :not(footer) {
+  margin: 0;
+}
+
+.luogu-epigraph:has(> footer) > :nth-last-child(2) {
+  padding-bottom: 0.15em;
+  border-bottom: 1px solid var(--vscode-foreground);
 }
 
 .luogu-epigraph > footer {
-  margin-top: 0.5em;
+  margin-top: 0.25em;
   text-align: right;
 }
 

--- a/webview/markdownViewer/luoguMarkdownExtensions.ts
+++ b/webview/markdownViewer/luoguMarkdownExtensions.ts
@@ -52,6 +52,7 @@ function transformDirective(node: MdastNode) {
     addMdastClass(node, 'luogu-epigraph');
     const label = node.children?.find(isDirectiveLabel);
     if (label && node.children) {
+      addMdastClass(node, 'luogu-epigraph-with-footer');
       node.children = node.children.filter(child => child !== label);
       (label.data ??= {}).hName = 'footer';
       node.children.push(label);
@@ -244,6 +245,7 @@ function enhanceCodeBlock(pre: Element) {
     }
     return line;
   });
+  addHastClass(pre, 'luogu-code-enhanced');
   if (showLineNumbers) addHastClass(pre, 'luogu-code-line-numbers');
 }
 

--- a/webview/markdownViewer/luoguMarkdownExtensions.ts
+++ b/webview/markdownViewer/luoguMarkdownExtensions.ts
@@ -1,0 +1,260 @@
+import type { Element, ElementContent, Root, RootContent } from 'hast';
+
+type MdastNode = {
+  type: string;
+  name?: string;
+  attributes?: Record<string, string>;
+  data?: Record<string, unknown>;
+  children?: MdastNode[];
+  value?: string;
+};
+
+const calloutNames = ['info', 'success', 'warning', 'error'] as const;
+const defaultCalloutTitles: Record<(typeof calloutNames)[number], string> = {
+  info: '提示',
+  success: '成功',
+  warning: '警告',
+  error: '错误'
+};
+
+function addMdastClass(node: MdastNode, ...classNames: string[]) {
+  const data = (node.data ??= {});
+  const properties = ((data.hProperties as Record<string, unknown>) ??= {});
+  const current = properties.className;
+  properties.className = [
+    ...(Array.isArray(current)
+      ? current
+      : typeof current === 'string'
+        ? [current]
+        : []),
+    ...classNames
+  ];
+}
+
+function isDirectiveLabel(node: MdastNode | undefined) {
+  return node?.type === 'paragraph' && node.data?.directiveLabel === true;
+}
+
+function transformDirective(node: MdastNode) {
+  if (node.type !== 'containerDirective') return;
+
+  if (node.name === 'align') {
+    const alignment = Object.hasOwn(node.attributes ?? {}, 'right')
+      ? 'right'
+      : 'center';
+    (node.data ??= {}).hName = 'div';
+    addMdastClass(node, 'luogu-align', `luogu-align-${alignment}`);
+    return;
+  }
+
+  if (node.name === 'epigraph') {
+    (node.data ??= {}).hName = 'blockquote';
+    addMdastClass(node, 'luogu-epigraph');
+    const label = node.children?.find(isDirectiveLabel);
+    if (label && node.children) {
+      node.children = node.children.filter(child => child !== label);
+      (label.data ??= {}).hName = 'footer';
+      node.children.push(label);
+    }
+    return;
+  }
+
+  if (!calloutNames.includes(node.name as (typeof calloutNames)[number]))
+    return;
+  const kind = node.name as (typeof calloutNames)[number];
+  (node.data ??= {}).hName = 'details';
+  addMdastClass(node, 'luogu-callout', `luogu-callout-${kind}`);
+  const properties = ((node.data ??= {}).hProperties ??= {}) as Record<
+    string,
+    unknown
+  >;
+  if (Object.hasOwn(node.attributes ?? {}, 'open')) properties.open = true;
+
+  const children = (node.children ??= []);
+  let label = children.find(isDirectiveLabel);
+  if (label) {
+    node.children = children.filter(child => child !== label);
+  } else {
+    label = {
+      type: 'paragraph',
+      data: { directiveLabel: true },
+      children: [{ type: 'text', value: defaultCalloutTitles[kind] }]
+    };
+  }
+  (label.data ??= {}).hName = 'summary';
+  node.children.unshift(label);
+}
+
+function transformMdastChildren(parent: MdastNode) {
+  const children = parent.children;
+  if (!children) return;
+
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index];
+    if (
+      child.type === 'leafDirective' &&
+      child.name === 'cute-table' &&
+      Object.hasOwn(child.attributes ?? {}, 'tuack')
+    ) {
+      const table = children[index + 1];
+      children.splice(index, 1);
+      index--;
+      if (table?.type === 'table') {
+        addMdastClass(table, 'luogu-cute-table', 'luogu-cute-table-tuack');
+      }
+      continue;
+    }
+
+    transformDirective(child);
+    transformMdastChildren(child);
+  }
+}
+
+export function remarkLuoguMarkdownExtensions() {
+  return (tree: MdastNode) => transformMdastChildren(tree);
+}
+
+function getClassNames(element: Element) {
+  const value = element.properties.className;
+  if (Array.isArray(value)) return value.map(String);
+  return typeof value === 'string' ? [value] : [];
+}
+
+function addHastClass(element: Element, ...classNames: string[]) {
+  element.properties.className = [...getClassNames(element), ...classNames];
+}
+
+function textContent(node: RootContent): string {
+  if (node.type === 'text') return node.value;
+  if ('children' in node) return node.children.map(textContent).join('');
+  return '';
+}
+
+function collectTableRows(node: Element): Element[] {
+  const rows: Element[] = [];
+  const walk = (current: ElementContent) => {
+    if (current.type !== 'element') return;
+    if (current.tagName === 'tr') {
+      rows.push(current);
+      return;
+    }
+    current.children.forEach(walk);
+  };
+  node.children.forEach(walk);
+  return rows;
+}
+
+function mergeTableCells(table: Element) {
+  const rows = collectTableRows(table);
+  const grid: Array<Array<Element | undefined>> = [];
+
+  rows.forEach((row, rowIndex) => {
+    const cells = row.children.filter(
+      (child): child is Element =>
+        child.type === 'element' &&
+        (child.tagName === 'td' || child.tagName === 'th')
+    );
+    const mergedUpThisRow = new Set<Element>();
+    grid[rowIndex] = [];
+
+    cells.forEach((cell, columnIndex) => {
+      const marker = textContent(cell).trim();
+      if (marker === '^') {
+        const target = grid[rowIndex - 1]?.[columnIndex];
+        if (target) {
+          if (!mergedUpThisRow.has(target)) {
+            const rowSpan = Number(target.properties.rowSpan ?? 1);
+            target.properties.rowSpan = rowSpan + 1;
+            mergedUpThisRow.add(target);
+          }
+          grid[rowIndex][columnIndex] = target;
+          row.children = row.children.filter(child => child !== cell);
+          return;
+        }
+      } else if (marker === '<') {
+        const target = grid[rowIndex][columnIndex - 1];
+        if (target) {
+          const colSpan = Number(target.properties.colSpan ?? 1);
+          target.properties.colSpan = colSpan + 1;
+          grid[rowIndex][columnIndex] = target;
+          row.children = row.children.filter(child => child !== cell);
+          return;
+        }
+      }
+      grid[rowIndex][columnIndex] = cell;
+    });
+  });
+}
+
+function splitNodesIntoLines(nodes: ElementContent[]): ElementContent[][] {
+  const lines: ElementContent[][] = [[]];
+
+  for (const node of nodes) {
+    if (node.type === 'text') {
+      const parts = node.value.split('\n');
+      parts.forEach((part, index) => {
+        if (part) lines.at(-1)?.push({ ...node, value: part });
+        if (index < parts.length - 1) lines.push([]);
+      });
+      continue;
+    }
+
+    if (node.type === 'element') {
+      const elementLines = splitNodesIntoLines(node.children);
+      elementLines.forEach((children, index) => {
+        if (children.length) lines.at(-1)?.push({ ...node, children });
+        if (index < elementLines.length - 1) lines.push([]);
+      });
+      continue;
+    }
+
+    lines.at(-1)?.push(node);
+  }
+
+  return lines;
+}
+
+function enhanceCodeBlock(pre: Element) {
+  const code = pre.children.find(
+    (child): child is Element =>
+      child.type === 'element' && child.tagName === 'code'
+  );
+  if (!code) return;
+  const codeData = code.data as Record<string, unknown> | undefined;
+  const meta = typeof codeData?.meta === 'string' ? codeData.meta : '';
+  const showLineNumbers = /(?:^|\s)line-numbers(?:\s|$)/.test(meta);
+  const lineRange = meta.match(/(?:^|\s)lines=(\d+)-(\d+)(?:\s|$)/);
+  if (!showLineNumbers && !lineRange) return;
+
+  let lines = splitNodesIntoLines(code.children);
+  if (lines.length > 1 && lines.at(-1)?.length === 0)
+    lines = lines.slice(0, -1);
+  const rangeStart = lineRange ? Number(lineRange[1]) : -1;
+  const rangeEnd = lineRange ? Number(lineRange[2]) : -1;
+  code.children = lines.map((children, index): Element => {
+    const lineNumber = index + 1;
+    const line: Element = {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['luogu-code-line'] },
+      children
+    };
+    if (lineNumber >= rangeStart && lineNumber <= rangeEnd) {
+      addHastClass(line, 'luogu-code-line-highlighted');
+    }
+    return line;
+  });
+  if (showLineNumbers) addHastClass(pre, 'luogu-code-line-numbers');
+}
+
+export function rehypeLuoguMarkdownExtensions() {
+  return (tree: Root) => {
+    const walk = (node: RootContent) => {
+      if (node.type !== 'element') return;
+      if (node.tagName === 'table') mergeTableCells(node);
+      if (node.tagName === 'pre') enhanceCodeBlock(node);
+      node.children.forEach(walk);
+    };
+    tree.children.forEach(walk);
+  };
+}


### PR DESCRIPTION
修复 #206 的同时，支持所有[洛谷帮助中心](https://help.luogu.com.cn/rules/academic/handbook/markdown#table)中提到的 markdown 新特性。

可以通过[U712391](https://www.luogu.com.cn/problem/U712391)测试显示效果，这里放几个截图

<img width="510" height="574" alt="image" src="https://github.com/user-attachments/assets/2afac41f-f50b-4e19-b9d9-80e277cfe3f7" />

<img width="560" height="473" alt="image" src="https://github.com/user-attachments/assets/c15a3437-b73a-4059-b4d1-b59e6c1f9af3" />

<img width="274" height="244" alt="image" src="https://github.com/user-attachments/assets/1520610e-d715-494e-bb7d-81c5c9ebfa69" />

<img width="823" height="109" alt="image" src="https://github.com/user-attachments/assets/6f776966-56b4-486b-b838-eabc0f3cb66b" />

<img width="408" height="496" alt="image" src="https://github.com/user-attachments/assets/41c79374-cd24-45ca-bf23-6ad53635f8ad" />
